### PR TITLE
Python 3 compatibility

### DIFF
--- a/example/simple_batched_pixel_sum/batched_pixel_sum_controller.py
+++ b/example/simple_batched_pixel_sum/batched_pixel_sum_controller.py
@@ -37,7 +37,7 @@ class BatchedPixelSumController(Controller):
     def _send_mb(self):
         self.init_data(self._batch_port)
 
-        for i in range(int(self._dataset.shape[0]/self._batch_size)):
+        for i in range(self._dataset.shape[0] // self._batch_size):
             batch_start = i*self._batch_size
             batch_stop = (i + 1)*self._batch_size
             self.send_mb(self._dataset[batch_start:batch_stop])

--- a/example/simple_batched_pixel_sum/batched_pixel_sum_controller.py
+++ b/example/simple_batched_pixel_sum/batched_pixel_sum_controller.py
@@ -3,7 +3,8 @@ import os
 import sys
 import gzip
 import time
-import cPickle
+import six
+from six.moves import cPickle
 from multiprocessing import Process
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -14,8 +15,10 @@ class BatchedPixelSumController(Controller):
 
     def __init__(self, control_port, batch_port, dataset, batch_size):
         Controller.__init__(self, control_port, None)
-        # The data socket should be initialized in the process that will handle the batch.
-        # That is why it's not initialized in the parent constructor. Second param = None
+        # The data socket should be initialized in the process that will handle
+        # the batch.
+        # That is why it's not initialized in the parent constructor. Second
+        # param = None
         self._batch_port = batch_port
 
         self._start_time = None
@@ -34,7 +37,7 @@ class BatchedPixelSumController(Controller):
     def _send_mb(self):
         self.init_data(self._batch_port)
 
-        for i in xrange(self._dataset.shape[0]/self._batch_size):
+        for i in range(int(self._dataset.shape[0]/self._batch_size)):
             batch_start = i*self._batch_size
             batch_stop = (i + 1)*self._batch_size
             self.send_mb(self._dataset[batch_start:batch_stop])
@@ -43,7 +46,8 @@ class BatchedPixelSumController(Controller):
         print("Done Sending MB.")
 
         # TODO: Find a solution for this
-        # Sleeping to give the chance to the worker to empty the queue before the MB process dies
+        # Sleeping to give the chance to the worker to empty the queue before
+        # the MB process dies
         import time
         time.sleep(2)
 
@@ -62,12 +66,14 @@ class BatchedPixelSumController(Controller):
 
         elif 'done' in req:
             self._nb_batch_processed += req['done']
-            print("{} batches processed by worker so far.".format(self._nb_batch_processed))
+            print("{} batches processed by worker so far."
+                  .format(self._nb_batch_processed))
 
         if self._nb_batch_processed == self._nb_batch_to_process:
             control_response = 'stop'
             self.worker_is_done(worker_id)
-            print("Training time {0:.4f}s".format(time.time() - self._start_time))
+            print("Training time {0:.4f}s"
+                  .format(time.time() - self._start_time))
         return control_response
 
 
@@ -75,9 +81,13 @@ def parse_arguments():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--batch_port', default=5566, type=int, required=False, help='Port on which the batches will be transfered.')
-    parser.add_argument('--control_port', default=5567, type=int, required=False, help='Port on which the control commands will be sent.')
-    parser.add_argument('--batch-size', default=1000, type=int, required=False, help='Size of the batches.')
+    parser.add_argument('--batch_port', default=5566, type=int, required=False,
+                        help='Port on which the batches will be transfered.')
+    parser.add_argument('--control_port', default=5567, type=int,
+                        required=False, help='Port on which the control '
+                        'commands will be sent.')
+    parser.add_argument('--batch-size', default=1000, type=int, required=False,
+                        help='Size of the batches.')
 
     return parser.parse_args()
 
@@ -102,7 +112,10 @@ if __name__ == '__main__':
     get_mnist(mnist_path)
 
     with gzip.open(mnist_path, 'rb') as f:
-        train_set, _, _ = cPickle.load(f)
+        kwargs = {}
+        if six.PY3:
+            kwargs['encoding'] = 'latin1'
+        train_set, _, _ = cPickle.load(f, **kwargs)
 
     controller = BatchedPixelSumController(control_port=args.control_port,
                                            batch_port=args.batch_port,

--- a/example/simple_batched_pixel_sum/batched_pixel_sum_worker.py
+++ b/example/simple_batched_pixel_sum/batched_pixel_sum_worker.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 import os
 import sys
 import gzip
-import cPickle
+import six
+from six.moves import cPickle
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -33,9 +34,12 @@ class BatchedPixelSum(object):
 
         data_shape = self._worker.send_req('get_data_shape')
 
-        self._computed_sum = theano.shared(value=np.zeros(data_shape, dtype=theano.config.floatX), name='sum', borrow=True)
+        self._computed_sum = theano.shared(
+            value=np.zeros(data_shape, dtype=theano.config.floatX),
+            name='sum', borrow=True)
 
-        self._worker.init_shared_params(params=[self._computed_sum], param_sync_rule=SUMSync())
+        self._worker.init_shared_params(params=[self._computed_sum],
+                                        param_sync_rule=SUMSync())
 
         input = T.matrix(dtype=theano.config.floatX)
         batch_sum = T.sum(input, axis=0, dtype=theano.config.floatX)
@@ -56,8 +60,9 @@ class BatchedPixelSum(object):
 
             if step == 'train':
                 print("# Training", end=' ')
-                # TODO: Having a fix number of MB before sync can cause problems
-                for i in xrange(nb_batches_before_sync):
+                # TODO: Having a fix number of MB before sync can cause
+                # problems
+                for i in range(nb_batches_before_sync):
                     data = np.asarray(self._worker.recv_mb())
                     print(".", end=' ')
                     self._update_sum(data)
@@ -80,8 +85,11 @@ def parse_arguments():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--batch_port', default=5566, type=int, required=False, help='Port on which the batches will be transfered.')
-    parser.add_argument('--control_port', default=5567, type=int, required=False, help='Port on which the control commands will be sent.')
+    parser.add_argument('--batch_port', default=5566, type=int, required=False,
+                        help='Port on which the batches will be transfered.')
+    parser.add_argument('--control_port', default=5567, type=int,
+                        required=False, help='Port on which the control '
+                        'commands will be sent.')
 
     return parser.parse_args()
 
@@ -97,6 +105,9 @@ if __name__ == '__main__':
 
     # Get actual answer for testing
     with gzip.open("../data/mnist.pkl.gz", 'rb') as f:
-        train_set, _, _ = cPickle.load(f)
+        kwargs = {}
+        if six.PY3:
+            kwargs['encoding'] = 'latin1'
+        train_set, _, _ = cPickle.load(f, **kwargs)
     real_sum = train_set[0].sum(axis=0, dtype=theano.config.floatX)
     assert_allclose(computed_sum, real_sum)

--- a/platoon/param_sync.py
+++ b/platoon/param_sync.py
@@ -89,7 +89,7 @@ class EASGD(ParamSyncRule):
             local_ups.append(p_local - diff)
             master_ups.append(p_master + diff)
         return theano.function(master_inps, master_ups,
-                               updates=zip(local_params, local_ups))
+                               updates=list(zip(local_params, local_ups)))
 
     def update_params(self, local_params, master_params):
         for p_local, p_master in zip(local_params, master_params):


### PR DESCRIPTION
The `simple_batched_pixel` example seems to run in both Python 2 and 3 now.

* Use `send_json` and `recv_json` because `recv` and `send` don't like unicode strings.
* Use `memoryview` instead of `buffer`
* Fix some PEP8 errors in the `simple_batched_pixel` example
* Make the `simple_batched_pixel` example Python 3 compatible (`cPickle` and `xrange`)

Fixes #53.