### PR TITLE
Fix wrong shlex argument

### DIFF
--- a/scripts/platoon-launcher
+++ b/scripts/platoon-launcher
@@ -44,11 +44,11 @@ if __name__ == '__main__':
     print("### Launching experiment: {}".format(args.experiment_name))
     process_map = {}
 
-    p = launch_process(logs_folder, args.experiment_name, shlex.split(args.controller_args), "cpu", "controller")
+    p = launch_process(logs_folder, args.experiment_name, shlex.split(args.controller_args or ''), "cpu", "controller")
     process_map[p.pid] = ('Controller', p)
 
     for device in args.gpu_list:
-        worker_process = launch_process(logs_folder, args.experiment_name, shlex.split(args.workers_args), device)
+        worker_process = launch_process(logs_folder, args.experiment_name, shlex.split(args.workers_args or ''), device)
         process_map[worker_process.pid] = ("Worker{}".format(device),
                                            worker_process)
 


### PR DESCRIPTION
If you don't pass controller or worker arguments, `args.controller_args` and `args.worker_args` are `None`, which makes `shlex.split` try to read from `stdin` and halt the entire script.