### PR TITLE
Made launcher script + module use launching Python version

### DIFF
--- a/platoon/util.py
+++ b/platoon/util.py
@@ -88,7 +88,7 @@ def launch_process(logs_folder, experiment_name, args, device,
                 executable = ["-m", "platoon.channel.controller"]
             else:
                 executable = ["{0}_{1}.py".format(experiment_name, process_type)]
-            command = ["python", "-u"] + executable
+            command = [sys.executable, "-u"] + executable
             if args:
                 command += args
             process = subprocess.Popen(command, bufsize=0, stdout=stdout_file, stderr=stderr_file, env=env)

--- a/scripts/platoon-launcher
+++ b/scripts/platoon-launcher
@@ -130,7 +130,7 @@ if __name__ == '__main__':
             executable = ["-m", "platoon.channel.controller"]
         else:
             executable = ["{}_controller.py".format(controller_type)]
-        command += ["python", "-u"] + executable
+        command += [sys.executable, "-u"] + executable
         command += [args.experiment_name, logs_folder, "--multi"]
         if args.controller_args:
             command += shlex.split(args.controller_args)


### PR DESCRIPTION
Currently internal calls to start python subprocesses are hardcoded to use the string `python`.

This PR uses `sys.executable` instead, which points to the currently running Python version.

This allows e.g. the `platoon-launcher` script to work with Python 3 installations which are started at the shell using `python3` instead of simply `python`.